### PR TITLE
Add server setup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ python scripts/download_weights.py
 ```bash
 python run.py
 ```
-Або скористайтеся скриптом [setup_server.sh](./setup_server.sh) для автоматичного налаштування.
+Також можна запустити скрипт `sudo bash scripts/setup_server.sh` для автоматичного налаштування.
 
 
 

--- a/instal.md
+++ b/instal.md
@@ -26,4 +26,6 @@
    ```
    API буде доступний на `http://<server-ip>:8000`.
 
+7. **Автоматична установка:** запустіть `sudo bash scripts/setup_server.sh`.
+
 При необхідності налаштуйте reverse proxy (наприклад, Nginx) та службу systemd для автозапуску.

--- a/scripts/setup_server.sh
+++ b/scripts/setup_server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Автоматичне налаштування сервера для NutriScan
+set -e
+
+# Оновлення списку пакетів і встановлення Python
+apt update
+apt install -y python3 python3-venv python3-pip
+
+# Створення та активація віртуального середовища
+python3 -m venv venv
+source venv/bin/activate
+
+# Встановлення залежностей
+pip install -r requirements.txt
+
+# Завантаження ваг моделей
+python scripts/download_weights.py
+


### PR DESCRIPTION
## Summary
- add `scripts/setup_server.sh` to automate server provisioning
- document the new script in installation docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d39de477083208742573a640971bc