### PR TITLE
Update model weights URL

### DIFF
--- a/nutriscan/models/classifier.py
+++ b/nutriscan/models/classifier.py
@@ -1,7 +1,9 @@
 import torch
 from pathlib import Path
 
-MODEL_URL = "https://huggingface.co/dwililiya/food101-model-classification"
+# Пряме посилання на файл з вагами моделі (EfficientNet-B0)
+# У репозиторії HuggingFace файл називається `weights.pt`
+MODEL_URL = "https://huggingface.co/dwililiya/food101-model-classification/resolve/main/weights.pt"
 
 class FoodClassifier:
     """Wrapper for food classification model."""


### PR DESCRIPTION
## Summary
- fix direct link to FoodClassifier weights

## Testing
- `python scripts/download_weights.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685d39d3670883209ca649fd397fa4ec