### PR TITLE
Реалізація закриття кешу при завершенні сервера

### DIFF
--- a/nutriscan/api/openfoodfacts.py
+++ b/nutriscan/api/openfoodfacts.py
@@ -54,6 +54,14 @@ class FoodInfoCache:
         )
         self.conn.commit()
 
+    def close(self) -> None:
+        """Закриває з'єднання з базою даних."""
+        self.conn.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+
 
 def fetch_info(name: str) -> dict[str, Any] | None:
     params = {"search_terms": name, "page_size": 1, "fields": "nutriments"}

--- a/nutriscan/backend.py
+++ b/nutriscan/backend.py
@@ -5,7 +5,7 @@ import io
 
 from .models.classifier import FoodClassifier
 from .models.detector import IngredientDetector
-from .api.openfoodfacts import get_nutrition
+from .api.openfoodfacts import get_nutrition, cache
 from .utils.weight_estimation import estimate_weight
 
 app = FastAPI()
@@ -14,6 +14,12 @@ detector = IngredientDetector()
 
 classifier.load()
 detector.load()
+
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    """Закриття ресурсів при завершенні роботи сервера."""
+    cache.close()
 
 
 class IngredientResult(BaseModel):


### PR DESCRIPTION
## Summary
- додано метод `close` та деструктор у `FoodInfoCache`
- підключено виклик `cache.close()` у події завершення FastAPI

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6866c4b1e7e48320ac3fd4c2ecd4cd59