### PR TITLE
Використання httpx та асинхронний доступ до API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 * Python: 3.10+
 * RAM: 8+ GB
 * GPU: бажано, але не обов’язково
-* Бібліотеки: PyTorch, OpenCV, pandas, numpy, gradio / streamlit, requests, sqlite3
+* Бібліотеки: PyTorch, OpenCV, pandas, numpy, gradio / streamlit, httpx, sqlite3
 
 4. Архітектура
    \[Фото] -> \[Класифікатор страв] -> \[Segmenter інгредієнтів] -> \[Оцінка ваги] -> \[Open Food Facts API] -> \[Обчислення] -> \[UI]

--- a/nutriscan/backend.py
+++ b/nutriscan/backend.py
@@ -52,7 +52,7 @@ async def analyze(image: UploadFile = File(...)):
         name = det.get("label", "ingredient")
         area = det.get("area", 0)
         weight = estimate_weight(area)
-        info = get_nutrition(name) or {}
+        info = await get_nutrition(name) or {}
         calories = info.get("calories")
         if calories is not None:
             total_calories += (calories / 100) * weight

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.103.1
 uvicorn==0.23.2
 pydantic==1.10.12
-requests==2.31.0
+httpx==0.25.0
 pillow==10.0.0
 torch==2.0.1
 torchvision==0.15.2

--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -1,4 +1,5 @@
-import requests
+import asyncio
+import httpx
 from pathlib import Path
 
 from nutriscan.models.classifier import MODEL_URL as CLASSIFIER_URL
@@ -8,20 +9,21 @@ WEIGHTS_DIR = Path("weights")
 WEIGHTS_DIR.mkdir(exist_ok=True)
 
 
-def download(url: str, dest: Path) -> None:
+async def download(url: str, dest: Path) -> None:
     if dest.exists():
         print(f"{dest} вже існує, пропускаємо завантаження")
         return
     print(f"Завантаження {url} до {dest}")
-    response = requests.get(url, timeout=30)
-    response.raise_for_status()
-    dest.write_bytes(response.content)
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        dest.write_bytes(response.content)
 
 
-def main() -> None:
-    download(CLASSIFIER_URL, WEIGHTS_DIR / "classifier.pt")
-    download(DETECTOR_URL, WEIGHTS_DIR / "detector.pt")
+async def main() -> None:
+    await download(CLASSIFIER_URL, WEIGHTS_DIR / "classifier.pt")
+    await download(DETECTOR_URL, WEIGHTS_DIR / "detector.pt")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- migrate from `requests` to `httpx`
- make `fetch_info` and `get_nutrition` async
- await nutrition info in `/analyze`
- update weight download script to async
- adjust requirements and docs

## Testing
- `python -m py_compile nutriscan/api/openfoodfacts.py nutriscan/backend.py scripts/download_weights.py`

------
https://chatgpt.com/codex/tasks/task_e_6866c4b035a0832098fb8572b3c98357