### PR TITLE
Fix extraneous lines in download_weights script

### DIFF
--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -14,12 +14,10 @@ async def download(url: str, dest: Path) -> None:
         print(f"{dest} вже існує, пропускаємо завантаження")
         return
     print(f"Завантаження {url} до {dest}")
-codex/заміна-requests-на-httpx.asyncclient
     async with httpx.AsyncClient(timeout=30) as client:
         response = await client.get(url)
         response.raise_for_status()
         dest.write_bytes(response.content)
-main
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- cleanup `scripts/download_weights.py` by removing leftover lines

## Testing
- `python -m py_compile scripts/download_weights.py`


------
https://chatgpt.com/codex/tasks/task_e_6866d46f2e088320b51ed229e887485f