### PR TITLE
Fix trailing line in server setup script

### DIFF
--- a/scripts/setup_server.sh
+++ b/scripts/setup_server.sh
@@ -18,4 +18,3 @@ python scripts/download_weights.py
 
 # Запуск сервера
 python run.py
-


### PR DESCRIPTION
## Summary
- clean up `setup_server.sh` to remove stray trailing blank line
- ensure the script ends with `python run.py`

## Testing
- `git show HEAD:./scripts/setup_server.sh | tail -n 2`

------
https://chatgpt.com/codex/tasks/task_e_6866f35812c48320a6a8dd6b04055521