### PR TITLE
Implement OpenAI client function

### DIFF
--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -1,0 +1,41 @@
+import os
+import json
+import urllib.request
+
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def analyze_image_base64(image_base64: str) -> dict:
+    """Send a base64 image to OpenAI Vision and return raw text response."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+
+    payload = {
+        "model": "gpt-4-vision-preview",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe the food in this image"},
+                    {"type": "image_url", "image_url": {"url": image_base64}},
+                ],
+            }
+        ],
+        "max_tokens": 200,
+    }
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        OPENAI_API_URL,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        resp_data = json.load(resp)
+
+    raw_text = resp_data["choices"][0]["message"]["content"]
+    return {"raw_response": raw_text}

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,23 @@
+import os
+import io
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.openai_client import analyze_image_base64
+
+
+@pytest.mark.asyncio
+async def test_analyze_image_base64(monkeypatch):
+    os.environ['OPENAI_API_KEY'] = 'test'
+    dummy_base64 = 'data:image/jpeg;base64,dGVzdA=='
+    fake_resp = {"choices": [{"message": {"content": "sample"}}]}
+    fake_file = io.BytesIO(json.dumps(fake_resp).encode())
+    mock = MagicMock()
+    mock.__enter__.return_value = fake_file
+    mock.__exit__.return_value = False
+    with patch('urllib.request.urlopen', return_value=mock):
+        result = analyze_image_base64(dummy_base64)
+    assert result == {"raw_response": "sample"}
+


### PR DESCRIPTION
## Summary
- add OpenAI Vision request helper
- unit test using mocked HTTP call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6888b265897c832092a0b93fc52d2dd3