### PR TITLE
Update openai_client test to sync

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -8,8 +8,7 @@ import pytest
 from app.openai_client import analyze_image_base64
 
 
-@pytest.mark.asyncio
-async def test_analyze_image_base64(monkeypatch):
+def test_analyze_image_base64(monkeypatch):
     os.environ['OPENAI_API_KEY'] = 'test'
     dummy_base64 = 'data:image/jpeg;base64,dGVzdA=='
     fake_resp = {"choices": [{"message": {"content": "sample"}}]}


### PR DESCRIPTION
## Summary
- update `test_analyze_image_base64` to be synchronous

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6888cc6a8a448320915cd066292f2f80