### PR TITLE
Fix test imports for app

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,3 +1,7 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import os
 import io
 import json

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,3 +1,7 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import pytest
 from httpx import AsyncClient
 from pathlib import Path


### PR DESCRIPTION
## Summary
- ensure the application can be imported in tests by adjusting the path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6888cdaea210832087b0313674183eba