### PR TITLE
Add pytest asyncio dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-multipart
 accelerate
 pytest
 httpx
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add pytest-asyncio to project requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6888cef290ac832090cdf1ec2e5e6781