### PR TITLE
Implement stages 4 and 5

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,10 @@ from fastapi import FastAPI, UploadFile, File
 from pathlib import Path
 import uvicorn
 
+from .image_utils import image_to_base64
+from .openai_client import analyze_image_base64
+from .parser import parse_openai_response
+
 app = FastAPI()
 
 UPLOAD_DIR = Path('tmp')
@@ -14,6 +18,20 @@ async def upload_image(image: UploadFile = File(...)):
         content = await image.read()
         f.write(content)
     return {"message": "Image received", "filename": image.filename}
+
+
+@app.post('/analyze/')
+async def analyze_image(image: UploadFile = File(...)):
+    """Accept an image, send to GPT-4 Vision and return parsed JSON."""
+    file_location = UPLOAD_DIR / image.filename
+    with open(file_location, 'wb') as f:
+        content = await image.read()
+        f.write(content)
+
+    img_b64 = image_to_base64(str(file_location))
+    raw = analyze_image_base64(img_b64)
+    result = parse_openai_response(raw["raw_response"])
+    return result
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/app/parser.py
+++ b/app/parser.py
@@ -1,0 +1,39 @@
+import json
+import re
+from typing import Dict, Any
+
+
+def parse_openai_response(text: str) -> Dict[str, Any]:
+    """Parse raw GPT text response into structured JSON.
+
+    The function tries to locate a JSON object within the provided
+    text. If totals are missing they are calculated from ingredients.
+    """
+    text = text.strip()
+    data = None
+
+    # Try direct JSON parse
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        # Look for JSON object within text
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            data = json.loads(match.group(0))
+
+    if not isinstance(data, dict):
+        raise ValueError("Could not parse OpenAI response")
+
+    ingredients = data.get("ingredients")
+    if isinstance(ingredients, list):
+        if "total" not in data:
+            total = {"calories_kcal": 0.0, "protein_g": 0.0, "fat_g": 0.0, "carbs_g": 0.0}
+            for ing in ingredients:
+                total["calories_kcal"] += float(ing.get("calories_kcal", 0))
+                total["protein_g"] += float(ing.get("protein_g", 0))
+                total["fat_g"] += float(ing.get("fat_g", 0))
+                total["carbs_g"] += float(ing.get("carbs_g", 0))
+            data["total"] = total
+        return data
+    else:
+        raise ValueError("JSON does not contain 'ingredients'")


### PR DESCRIPTION
## Summary
- add a parser for GPT responses
- integrate OpenAI vision with a new `/analyze/` endpoint

## Testing
- `pytest -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6888d832f37483209b7472dffa7aeaee